### PR TITLE
Fix example for `count` command not counting individual elements

### DIFF
--- a/functions/count.md
+++ b/functions/count.md
@@ -12,5 +12,5 @@ $ echo '{"numbers":[1,2,3,4,5,6,7,8,9]}' | dasel -r json 'numbers.count()'
 1
 
 $ echo '{"numbers":[1,2,3,4,5,6,7,8,9]}' | dasel -r json 'numbers.all().count()'
-1
+9
 ```


### PR DESCRIPTION
This is a simple change to update one of the examples for the `count` command. Running the last example from https://daseldocs.tomwright.me/functions/count gives the following result:

```
$ echo '{"numbers":[1,2,3,4,5,6,7,8,9]}' | dasel -r json 'numbers.all().count()'
9
```

Tested on v2.5.0 from Homebrew as well as of commit https://github.com/TomWright/dasel/commit/3aaa052388aade9ddb8921023327e5bd2fbec9b3.